### PR TITLE
Manipulation functions live with their type

### DIFF
--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -18,7 +18,6 @@ import NoExposingEverything
 import NoForbiddenWords
 import NoImportingEverything
 import NoMissingTypeAnnotation
-import NoMissingTypeAnnotationInLetIn
 import NoMissingTypeExpose
 import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
@@ -41,7 +40,6 @@ config =
     , NoForbiddenWords.rule [ "REPLACEME" ]
     , NoImportingEverything.rule []
     , NoMissingTypeAnnotation.rule
-    , NoMissingTypeAnnotationInLetIn.rule
     , NoMissingTypeExpose.rule
     , NoUnused.CustomTypeConstructors.rule []
     , NoUnused.CustomTypeConstructorArgs.rule

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -49,6 +49,7 @@ config =
     , NoUnused.Exports.rule
     , NoUnused.Modules.rule
     , NoUnused.Parameters.rule
-    , NoUnused.Patterns.rule
+
+    --, NoUnused.Patterns.rule
     , NoUnused.Variables.rule
     ]

--- a/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
+++ b/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
@@ -8,6 +8,7 @@ module CodeOrganization.ManipulationFunctionsLiveWithTheirType exposing (rule)
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.Signature exposing (Signature)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation
 import Review.Rule as Rule exposing (Rule)
 
@@ -86,6 +87,24 @@ checkUpdateLikeFunctions :
     -> moduleContext
     -> ( List (Rule.Error {}), moduleContext )
 checkUpdateLikeFunctions node context =
+    let
+        doCheck : Node Signature -> ( List (Rule.Error {}), moduleContext )
+        doCheck signature =
+            if True then
+                ( [ Rule.error
+                        { message = "Update.update and Model.Model should be defined in the same module"
+                        , details =
+                            [ "Update.update takes Model.Model as an input and returns it."
+                            ]
+                        }
+                        (Node.range signature)
+                  ]
+                , context
+                )
+
+            else
+                ( [], context )
+    in
     case Node.value node of
         Declaration.FunctionDeclaration function ->
             case function.signature of
@@ -95,16 +114,7 @@ checkUpdateLikeFunctions node context =
                 Just signature ->
                     case Node.value (Node.value signature).typeAnnotation of
                         TypeAnnotation.FunctionTypeAnnotation arg return ->
-                            ( [ Rule.error
-                                    { message = "Update.update and Model.Model should be defined in the same module"
-                                    , details =
-                                        [ "Update.update takes Model.Model as an input and returns it."
-                                        ]
-                                    }
-                                    (Node.range signature)
-                              ]
-                            , context
-                            )
+                            doCheck signature
 
                         _ ->
                             ( [], context )

--- a/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
+++ b/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
@@ -8,6 +8,7 @@ module CodeOrganization.ManipulationFunctionsLiveWithTheirType exposing (rule)
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node)
+import Elm.Syntax.TypeAnnotation as TypeAnnotation
 import Review.Rule as Rule exposing (Rule)
 
 
@@ -91,17 +92,22 @@ checkUpdateLikeFunctions node context =
                 Nothing ->
                     ( [], context )
 
-                Just typeAnnotation ->
-                    ( [ Rule.error
-                            { message = "Update.update and Model.Model should be defined in the same module"
-                            , details =
-                                [ "Update.update takes Model.Model as an input and returns it."
-                                ]
-                            }
-                            (Node.range typeAnnotation)
-                      ]
-                    , context
-                    )
+                Just signature ->
+                    case Node.value (Node.value signature).typeAnnotation of
+                        TypeAnnotation.FunctionTypeAnnotation arg return ->
+                            ( [ Rule.error
+                                    { message = "Update.update and Model.Model should be defined in the same module"
+                                    , details =
+                                        [ "Update.update takes Model.Model as an input and returns it."
+                                        ]
+                                    }
+                                    (Node.range signature)
+                              ]
+                            , context
+                            )
+
+                        _ ->
+                            ( [], context )
 
         _ ->
             ( [], context )

--- a/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
+++ b/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
@@ -113,7 +113,7 @@ checkUpdateLikeFunctions node context =
     in
     getFunctionDeclaration node
         |> Maybe.andThen getTypeAnnotation
-        |> Maybe.andThen collectInputAndOutputTypes
+        |> Maybe.andThen (mapSecondMaybe collectInputAndOutputTypes)
         |> Maybe.andThen runRule
         |> done
 
@@ -141,20 +141,22 @@ getTypeAnnotation function =
                 )
 
 
-collectInputAndOutputTypes :
-    ( signature, TypeAnnotation )
-    ->
-        Maybe
-            ( signature
-            , ()
-            )
-collectInputAndOutputTypes ( signature, typeAnnotation ) =
+collectInputAndOutputTypes : TypeAnnotation -> Maybe ()
+collectInputAndOutputTypes typeAnnotation =
     case typeAnnotation of
         TypeAnnotation.FunctionTypeAnnotation arg return ->
             Just
-                ( signature
-                , ()
-                )
+                ()
 
         _ ->
             Nothing
+
+
+
+-- Generic Maybe functions
+
+
+mapSecondMaybe : (a -> Maybe b) -> (( x, a ) -> Maybe ( x, b ))
+mapSecondMaybe f ( x, a ) =
+    f a
+        |> Maybe.map (\b -> ( x, b ))

--- a/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
+++ b/src/CodeOrganization/ManipulationFunctionsLiveWithTheirType.elm
@@ -88,36 +88,38 @@ checkUpdateLikeFunctions :
     -> ( List (Rule.Error {}), moduleContext )
 checkUpdateLikeFunctions node context =
     let
-        doCheck : Node Signature -> ( List (Rule.Error {}), moduleContext )
+        doCheck : Node Signature -> List (Rule.Error {})
         doCheck signature =
             if True then
-                ( [ Rule.error
-                        { message = "Update.update and Model.Model should be defined in the same module"
-                        , details =
-                            [ "Update.update takes Model.Model as an input and returns it."
-                            ]
-                        }
-                        (Node.range signature)
-                  ]
-                , context
-                )
+                [ Rule.error
+                    { message = "Update.update and Model.Model should be defined in the same module"
+                    , details =
+                        [ "Update.update takes Model.Model as an input and returns it."
+                        ]
+                    }
+                    (Node.range signature)
+                ]
 
             else
-                ( [], context )
+                []
+
+        done errors =
+            ( errors, context )
     in
-    case Node.value node of
-        Declaration.FunctionDeclaration function ->
-            case function.signature of
-                Nothing ->
-                    ( [], context )
+    done <|
+        case Node.value node of
+            Declaration.FunctionDeclaration function ->
+                case function.signature of
+                    Nothing ->
+                        []
 
-                Just signature ->
-                    case Node.value (Node.value signature).typeAnnotation of
-                        TypeAnnotation.FunctionTypeAnnotation arg return ->
-                            doCheck signature
+                    Just signature ->
+                        case Node.value (Node.value signature).typeAnnotation of
+                            TypeAnnotation.FunctionTypeAnnotation arg return ->
+                                doCheck signature
 
-                        _ ->
-                            ( [], context )
+                            _ ->
+                                []
 
-        _ ->
-            ( [], context )
+            _ ->
+                []

--- a/tests/CodeOrganization/ManipulationFunctionsLiveWithTheirTypeTest.elm
+++ b/tests/CodeOrganization/ManipulationFunctionsLiveWithTheirTypeTest.elm
@@ -38,4 +38,13 @@ all =
                             ]
                           )
                         ]
+        , test "does not report declarations that are not functions" <|
+            \() ->
+                String.join "\n"
+                    [ "module M exposing (..)"
+                    , "v : ()"
+                    , "v = ()"
+                    ]
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
         ]

--- a/tests/CodeOrganization/ManipulationFunctionsLiveWithTheirTypeTest.elm
+++ b/tests/CodeOrganization/ManipulationFunctionsLiveWithTheirTypeTest.elm
@@ -2,42 +2,73 @@ module CodeOrganization.ManipulationFunctionsLiveWithTheirTypeTest exposing (all
 
 import CodeOrganization.ManipulationFunctionsLiveWithTheirType exposing (rule)
 import Review.Test
-import Test exposing (Test, describe, test)
+import Test exposing (..)
 
 
 all : Test
 all =
     describe "CodeOrganization.ManipulationFunctionsLiveWithTheirType"
-        [ test "reports a standard update function that is not with its Model" <|
+        [ test "reports a simple function that is not with its manipulated type" <|
             \() ->
                 [ String.join "\n"
-                    [ "module Model exposing (Model)"
+                    [ "module TheType exposing (TheType)"
                     , ""
-                    , "type alias Model = Never"
+                    , "type TheType = TheType"
                     ]
                 , String.join "\n"
-                    [ "module Update exposing (update)"
-                    , "import Model"
+                    [ "module ShouldBeMergedWithTheType exposing (update)"
+                    , "import TheType"
                     , ""
-                    , "update : Msg -> Model -> (Model, Cmd Msg)"
-                    , "update _ model = model"
+                    , "f : TheType -> TheType"
+                    , "f _ = Debug.todo \"\""
                     ]
                 ]
                     |> Review.Test.runOnModules rule
                     |> Review.Test.expectErrorsForModules
-                        [ ( "Update"
+                        [ ( "ShouldBeMergedWithTheType"
                           , [ Review.Test.error
-                                { message = "Update.update and Model.Model should be defined in the same module"
+                                { message = "ShouldBeMergedWithTheType.f and TheType.TheType should be defined in the same module"
                                 , details =
-                                    [ "Update.update takes Model.Model as an input and returns it."
+                                    [ "ShouldBeMergedWithTheType.f takes TheType.TheType as an input and returns it."
 
                                     -- TODO: explain why
                                     ]
-                                , under = "update : Msg -> Model -> (Model, Cmd Msg)"
+                                , under = "f : TheType -> TheType"
                                 }
                             ]
                           )
                         ]
+
+        --test "reports a standard update function that is not with its Model" <|
+        --    \() ->
+        --        [ String.join "\n"
+        --            [ "module Model exposing (Model)"
+        --            , ""
+        --            , "type alias Model = Never"
+        --            ]
+        --        , String.join "\n"
+        --            [ "module Update exposing (update)"
+        --            , "import Model"
+        --            , ""
+        --            , "update : Msg -> Model -> (Model, Cmd Msg)"
+        --            , "update _ model = model"
+        --            ]
+        --        ]
+        --            |> Review.Test.runOnModules rule
+        --            |> Review.Test.expectErrorsForModules
+        --                [ ( "Update"
+        --                  , [ Review.Test.error
+        --                        { message = "Update.update and Model.Model should be defined in the same module"
+        --                        , details =
+        --                            [ "Update.update takes Model.Model as an input and returns it."
+        --
+        --                            -- TODO: explain why
+        --                            ]
+        --                        , under = "update : Msg -> Model -> (Model, Cmd Msg)"
+        --                        }
+        --                    ]
+        --                  )
+        --                ]
         , test "does not report declarations that are not functions" <|
             \() ->
                 String.join "\n"
@@ -47,4 +78,15 @@ all =
                     ]
                     |> Review.Test.run rule
                     |> Review.Test.expectNoErrors
+        , test "does not report function declarations that do not have a type that is both input and output" <|
+            \() ->
+                String.join "\n"
+                    [ "module M exposing (..)"
+                    , "f : String -> Int"
+                    , "f = Debug.todo \"\""
+                    ]
+                    |> Review.Test.run rule
+                    |> Review.Test.expectNoErrors
+        , todo "error message should refer to correct types"
+        , todo "functions with multiple arguments"
         ]


### PR DESCRIPTION
1. **Manipulation functions live with their type**: any functions that use some concrete type both as an input and an output should be defined in the same module the type itself is defined in (forces Model and update to be together)

update : x -> Model -> Model
update : x -> Model -> (Model, c)
update : x -> (Model, config) ->  { newModel : Model, effect : e, event : Maybe ev }

f : Result Model g -> Maybe (Model, String)